### PR TITLE
Add typed marker file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     long_description_content_type="text/markdown",
     license="MIT",
     packages=find_packages(where="src"),
+    package_data={"pwinput": ["py.typed"]},
     package_dir={"": "src"},
     test_suite="tests",
     install_requires=[],


### PR DESCRIPTION
Due to lacking of `py.typed` and configuration of `package_data`, this package is not providing typed information. In my project using `pwinput`, `mypy` says:

```
...
gppt/auth.py:5: error: Skipping analyzing "pwinput": module is installed, but missing library stubs or py.typed marker
[import]
    import pwinput
    ^
gppt/auth.py:5: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
...
```

So I added them.

See: [PEP 561#Packaging Type Information](https://www.python.org/dev/peps/pep-0561/#id13)

>Package maintainers who wish to support type checking of their code MUST add a marker file named py.typed to their package supporting typing. This marker applies recursively: if a top-level package includes it, all its sub-packages MUST support type checking as well. To have this file installed with the package, maintainers can use existing packaging options such as package_data in distutils, shown below.